### PR TITLE
Replace "cass" with "cases" everywhere

### DIFF
--- a/src/pages/0.5/events/__snapshots__/index.test.tsx.snap
+++ b/src/pages/0.5/events/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`it renders 1`] = `
 <Example
   description="Example of how to emit events in Solidity"
-  html="<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cass for events are:</p>
+  html="<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cases for events are:</p>
 <ul>
 <li>Listening for events and updating user interface</li>
 <li>A cheap form of storage</li>

--- a/src/pages/0.5/events/index.html.ts
+++ b/src/pages/0.5/events/index.html.ts
@@ -3,7 +3,7 @@ export const version = "0.5.16"
 export const title = "Events"
 export const description = "Example of how to emit events in Solidity"
 
-const html = `<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cass for events are:</p>
+const html = `<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cases for events are:</p>
 <ul>
 <li>Listening for events and updating user interface</li>
 <li>A cheap form of storage</li>

--- a/src/pages/0.5/events/index.md
+++ b/src/pages/0.5/events/index.md
@@ -4,7 +4,7 @@ version: 0.5.16
 description: Example of how to emit events in Solidity
 ---
 
-`Events` allow logging to the Ethereum blockchain. Some use cass for events are:
+`Events` allow logging to the Ethereum blockchain. Some use cases for events are:
 
 - Listening for events and updating user interface
 - A cheap form of storage

--- a/src/pages/0.6/events/__snapshots__/index.test.tsx.snap
+++ b/src/pages/0.6/events/__snapshots__/index.test.tsx.snap
@@ -3,7 +3,7 @@
 exports[`it renders 1`] = `
 <Example
   description="Example of how to emit events in Solidity"
-  html="<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cass for events are:</p>
+  html="<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cases for events are:</p>
 <ul>
 <li>Listening for events and updating user interface</li>
 <li>A cheap form of storage</li>

--- a/src/pages/0.6/events/index.html.ts
+++ b/src/pages/0.6/events/index.html.ts
@@ -3,7 +3,7 @@ export const version = "0.6.10"
 export const title = "Events"
 export const description = "Example of how to emit events in Solidity"
 
-const html = `<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cass for events are:</p>
+const html = `<p><code>Events</code> allow logging to the Ethereum blockchain. Some use cases for events are:</p>
 <ul>
 <li>Listening for events and updating user interface</li>
 <li>A cheap form of storage</li>

--- a/src/pages/0.6/events/index.md
+++ b/src/pages/0.6/events/index.md
@@ -4,7 +4,7 @@ version: 0.6.10
 description: Example of how to emit events in Solidity
 ---
 
-`Events` allow logging to the Ethereum blockchain. Some use cass for events are:
+`Events` allow logging to the Ethereum blockchain. Some use cases for events are:
 
 - Listening for events and updating user interface
 - A cheap form of storage


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/3408480/102662872-ede54180-413c-11eb-8950-e29ba6cf7bc5.png)

Spelling error found in the wild at https://solidity-by-example.org/0.6/events/
