### PR TITLE
fix typos

### DIFF
--- a/src/pages/enum/index.md
+++ b/src/pages/enum/index.md
@@ -4,7 +4,7 @@ version: 0.7.6
 description: Example of enums in Solidity
 ---
 
-Solidity support enumerables and they are useful to model choice and keep track of state.
+Solidity supports enumerables and they are useful to model choice and keep track of state.
 
 Enums can be declared ouside of a contract.
 

--- a/src/pages/hashing/index.md
+++ b/src/pages/hashing/index.md
@@ -8,7 +8,7 @@ description: Example of hashing using Keccak256 in Solidity
 
 Some use cases are:
 
-- Creating an deterministic unique ID from a input
+- Creating a deterministic unique ID from a input
 - Commit-Reveal scheme
 - Compact cryptographic signature (by signing the hash instead of a larger input)
 

--- a/src/pages/structs/Structs.sol
+++ b/src/pages/structs/Structs.sol
@@ -29,7 +29,7 @@ contract Todos {
         todos.push(todo);
     }
 
-    // Solidity automatically created a getter for' todos' so
+    // Solidity automatically created a getter for 'todos' so
     // you don't actually need this function.
     function get(uint _index) public view
         returns (string memory text, bool completed)


### PR DESCRIPTION
enums page: `Solidity support enumerables`  ---->  `Solidity supports enumerables`
structs page: `for' todo'` ----> `for 'todo'`
hashing page: `Creating an deterministic` ----> `Creating a deterministic`