### PR TITLE
Update comment for int's

### DIFF
--- a/src/pages/primitives/Primitives.sol
+++ b/src/pages/primitives/Primitives.sol
@@ -18,7 +18,7 @@ contract Primitives {
 
     /*
     Negative numbers are allowed for int types.
-    Like uint, different ranges are available from uint8 to uint256
+    Like uint, different ranges are available from int8 to int256
     */
     int8 public i8 = -1;
     int256 public i256 = 456;


### PR DESCRIPTION
Just a minor change. 

Shouldn't this say: Like uint, different ranges are available from int8 to int256 (instead of uint).
