### PR TITLE
docs(pragma): fixed comment regarding pragma semver

### DIFF
--- a/src/pages/hello-world/HelloWorld.sol
+++ b/src/pages/hello-world/HelloWorld.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-// compiler version must be greater than or equal to 0.8.3 and less than 0.8.0
+// compiler version must be greater than or equal to 0.8.3 and less than 0.9.0
 pragma solidity ^0.8.3;
 
 contract HelloWorld {


### PR DESCRIPTION
I noticed a typo in the comment regarding the function of the caret in the pragma versioning. I believe the comment should read `and less than 0.9.0` rather than `and less than 0.8.0`.