### PR TITLE
triggering `fallback()` via `call()`

### DIFF
--- a/src/pages/call/Call.sol
+++ b/src/pages/call/Call.sol
@@ -30,8 +30,8 @@ contract Caller {
     }
 
     // Calling a function that does not exist triggers the fallback function.
-    function testCallDoesNotExist(address _addr) public {
-        (bool success, bytes memory data) = _addr.call(
+    function testCallDoesNotExist(address _addr) public payable {
+        (bool success, bytes memory data) = _addr.call{value: msg.value}(
             abi.encodeWithSignature("doesNotExist()")
         );
 


### PR DESCRIPTION
Correct me if I got the idea of this example wrong, pls. If we want to trigger `Receiver.fallback()`, then we should declare `testCallDoesNotExist()` as `payable`. And without passing `msg.value` the `fallback()` will be triggered with zero value.