### PR TITLE
improvement: using calldata instead of memory

### DIFF
--- a/src/pages/structs/Structs.sol
+++ b/src/pages/structs/Structs.sol
@@ -10,7 +10,7 @@ contract Todos {
     // An array of 'Todo' structs
     Todo[] public todos;
 
-    function create(string memory _text) public {
+    function create(string calldata _text) public {
         // 3 ways to initialize a struct
         // - calling it like a function
         todos.push(Todo(_text, false));
@@ -34,7 +34,7 @@ contract Todos {
     }
 
     // update text
-    function update(uint _index, string memory _text) public {
+    function update(uint _index, string calldata _text) public {
         Todo storage todo = todos[_index];
         todo.text = _text;
     }


### PR DESCRIPTION
In the examples I updated, the argument has the storage location memory.
When the functions get called externally, the arguments are kept in calldata
and copied to memory during ABI decoding (using the opcode calldataload and mstore).
When the argument is read in the function, the value is accesses in memory
using a mload. We can avoid all this logic by simply using calldata for
read-only arguments. In my proposal, instead of going via memory,
the value is directly read from calldata using calldataload.
I think this is important to expose good practices like this one to the user.

----

What do you think about this @t4sk? I'm ready to open a PR that changes memory argument to calldata argument when needed.