### PR TITLE
Change transfer function to call function for best and secure practice

### DIFF
--- a/src/pages/app/ether-wallet/EtherWallet.sol
+++ b/src/pages/app/ether-wallet/EtherWallet.sol
@@ -12,7 +12,8 @@ contract EtherWallet {
 
     function withdraw(uint _amount) external {
         require(msg.sender == owner, "caller is not owner");
-        payable(msg.sender).transfer(_amount);
+        (bool sucess, ) = msg.sender.call{value: _amount}("");
+        require(sucess,"Transfer failed.");
     }
 
     function getBalance() external view returns (uint) {


### PR DESCRIPTION
For good practice and  coherent with other code samples. Changed 'transfer' function to 'call' function.

[Link](https://consensys.net/diligence/blog/2019/09/stop-using-soliditys-transfer-now/)