### PR TITLE
Updated burn function in erc721

### DIFF
--- a/src/pages/app/erc721/ERC721.sol
+++ b/src/pages/app/erc721/ERC721.sol
@@ -240,6 +240,7 @@ contract ERC721 is IERC721 {
 
     function burn(uint tokenId) external {
         address owner = ownerOf(tokenId);
+        require(msg.sender == owner, "not owner of token");
 
         _approve(owner, address(0), tokenId);
 


### PR DESCRIPTION
Now requires caller to be owner to be able to burn token.