### PR TITLE
explicitly declare uint256

### DIFF
--- a/src/pages/primitives/index.html.ts
+++ b/src/pages/primitives/index.html.ts
@@ -31,7 +31,7 @@ const html = `<p>Here we introduce you to some primitive data types available in
         uint256 ranges from 0 to 2 ** 256 - 1
     */</span>
     <span class="hljs-keyword">uint8</span> <span class="hljs-keyword">public</span> u8 <span class="hljs-operator">=</span> <span class="hljs-number">1</span>;
-    <span class="hljs-keyword">uint</span> <span class="hljs-keyword">public</span> u256 <span class="hljs-operator">=</span> <span class="hljs-number">456</span>;
+    <span class="hljs-keyword">uint256</span> <span class="hljs-keyword">public</span> u256 <span class="hljs-operator">=</span> <span class="hljs-number">456</span>;
     <span class="hljs-keyword">uint</span> <span class="hljs-keyword">public</span> u <span class="hljs-operator">=</span> <span class="hljs-number">123</span>; <span class="hljs-comment">// uint is an alias for uint256</span>
 
     <span class="hljs-comment">/*
@@ -42,7 +42,7 @@ const html = `<p>Here we introduce you to some primitive data types available in
     int128 ranges from -2 ** 127 to 2 ** 127 - 1
     */</span>
     <span class="hljs-keyword">int8</span> <span class="hljs-keyword">public</span> i8 <span class="hljs-operator">=</span> <span class="hljs-number">-1</span>;
-    <span class="hljs-keyword">int</span> <span class="hljs-keyword">public</span> i256 <span class="hljs-operator">=</span> <span class="hljs-number">456</span>;
+    <span class="hljs-keyword">int256</span> <span class="hljs-keyword">public</span> i256 <span class="hljs-operator">=</span> <span class="hljs-number">456</span>;
     <span class="hljs-keyword">int</span> <span class="hljs-keyword">public</span> i <span class="hljs-operator">=</span> <span class="hljs-number">-123</span>; <span class="hljs-comment">// int is same as int256</span>
 
     <span class="hljs-comment">// minimum and maximum of int</span>


### PR DESCRIPTION
Primitives may benefit from explicitly declaring `uint256` and `int256` before `uint` and `int`. 