### PR TITLE
Fixes for PreventFrontrunning.sol

### DIFF
--- a/src/pages/hacks/front-running/PreventFrontRunning.sol
+++ b/src/pages/hacks/front-running/PreventFrontRunning.sol
@@ -89,7 +89,7 @@ contract SecuredFindThisHash {
 
     /* 
         Function to reveal the commit and get the reward. 
-        Users can get reveal solution only if the game is active and they have committed a solutionHash and not revealed yet.
+        Users can get reveal solution only if the game is active and they have committed a solutionHash before this block and not revealed yet.
         It generates an keccak256(msg.sender + solution + secret) and checks it with the previously commited hash.  
         Front runners will not be able to pass this check since the msg.sender is different.
         Then the actual solution is checked using keccak256(solution), if the solution matches, the winner is declared, 
@@ -101,6 +101,7 @@ contract SecuredFindThisHash {
     ) public gameActive {
         Commit storage commit = commits[msg.sender];
         require(commit.commitTime != 0, "Not committed yet");
+        require(commit.commitTime < block.timestamp, "Cannot reveal in the same block");
         require(!commit.revealed, "Already commited and revealed");
 
         bytes32 solutionHash = keccak256(

--- a/src/pages/hacks/front-running/PreventFrontRunning.sol
+++ b/src/pages/hacks/front-running/PreventFrontRunning.sol
@@ -109,7 +109,7 @@ contract SecuredFindThisHash {
         );
         require(solutionHash == commit.solutionHash, "Hash doesn't match");
 
-        require(keccak256(abi.encodePacked(_solution)) != hash, "Incorrect answer");
+        require(keccak256(abi.encodePacked(_solution)) == hash, "Incorrect answer");
 
         winner = msg.sender;
         ended = true;


### PR DESCRIPTION
This PR resolves two bugs in the PreventFrontrunning.sol.

1. The attacker can attack this smart contract by submitting both `commitSolution()` and `revealSolution()` transactions in the same block after seeing the correct solution in the mempool.
**Solution:** The commit 48a0b38ad2217a61ae41f1ecc80dff414cd4506c resolves this by ensuring the commit is done before the current block.
2. The solution-checking logic is incorrect since the correct solution must have the same hash as stored in the smart contract, not different. (Credits to @jokopopo for this issue)
**Solution:** The commit 63a2e19628750cb4598f9e2a02e67bf1e93d818e resolves this by changing the comparison operator from `!=` to `==`.
