### PR TITLE
Fix Typo in Shadowing Inherited State Variables Documentation

### DIFF
--- a/src/pages/shadowing-inherited-state-variables/index.md
+++ b/src/pages/shadowing-inherited-state-variables/index.md
@@ -6,7 +6,7 @@ keywords: [state, variables, variable, shadow, shadowing, inheritance]
 cyfrinLink: https://www.cyfrin.io/glossary/shadowing-inherited-state-variables-solidity-code-example
 ---
 
-Unlike functions, state variables cannot be overridden by re-declaring it
+Unlike functions, state variables cannot be overridden by redeclaring it
 in the child contract.
 
 Let's learn how to correctly override inherited state variables.


### PR DESCRIPTION


Description:  
This pull request corrects a minor typo in the documentation for shadowing inherited state variables. The word "re-declaring" has been updated to "redeclaring" for improved clarity and consistency.