### PR TITLE
Handle Odd Number of Leaf Nodes in Merkle Tree Construction

### DIFF
--- a/contracts/src/app/merkle-tree/MerkleTree.sol
+++ b/contracts/src/app/merkle-tree/MerkleTree.sol
@@ -40,18 +40,25 @@ contract TestMerkleProof is MerkleProof {
         uint256 n = transactions.length;
         uint256 offset = 0;
 
-        while (n > 0) {
-            for (uint256 i = 0; i < n - 1; i += 2) {
+        while (n > 1) {
+            for (uint256 i = 0; i < n; i += 2) {
+                bytes32 left = hashes[offset+i];
+                bytes32 right;
+                if (i+1 < n) {
+                    right = hashes[offset + i + 1];
+                } else {
+                    right = left;
+                }
                 hashes.push(
                     keccak256(
                         abi.encodePacked(
-                            hashes[offset + i], hashes[offset + i + 1]
+                            left, right
                         )
                     )
                 );
             }
             offset += n;
-            n = n / 2;
+            n = (n+1) / 2;
         }
     }
 


### PR DESCRIPTION
#338 
Merkle tree example where an odd number of leaf nodes would result in an incorrect root hash. 

Previously, the last unpaired node was skipped during hashing. This fix ensures the tree remains valid by duplicating the last node when necessary.

#Fix
Replaced the loop inside the constructor with logic that handles both even and odd numbers of nodes:
```solidity
while (n > 1) {
    for (uint256 i = 0; i < n; i += 2) {
        bytes32 left = hashes[offset + i];
        bytes32 right;

        if (i + 1 < n) {
            right = hashes[offset + i + 1];
        } else {
            right = left; // duplicate last node if odd
        }

        hashes.push(keccak256(abi.encodePacked(left, right)));
    }
    offset += n;
    n = (n + 1) / 2;
}
```



